### PR TITLE
do not track cur_width through setenv

### DIFF
--- a/03-aflatin.c.patch
+++ b/03-aflatin.c.patch
@@ -1,5 +1,5 @@
---- a/src/autofit/aflatin.c	2014-07-07 23:10:20.716743596 +0200
-+++ b/src/autofit/aflatin.c	2014-07-07 23:32:36.263462412 +0200
+--- a/src/autofit/aflatin.c	2014-09-14 11:35:20.946193837 -0500
++++ b/src/autofit/aflatin.c	2014-09-14 11:58:37.726708173 -0500
 @@ -24,6 +24,7 @@
  #include "afpic.h"
  #include "aflatin.h"
@@ -8,7 +8,18 @@
  
  
  #ifdef AF_CONFIG_OPTION_USE_WARPER
-@@ -892,8 +893,33 @@
+@@ -40,6 +41,10 @@
+ #undef  FT_COMPONENT
+ #define FT_COMPONENT  trace_aflatin
+ 
++#ifdef FT_CONFIG_OPTION_INFINALITY_PATCHSET
++FT_Pos infinality_cur_width = 0;
++#endif
++
+ 
+   /*************************************************************************/
+   /*************************************************************************/
+@@ -892,8 +897,33 @@
      FT_Pos        delta;
      AF_LatinAxis  axis;
      FT_UInt       nn;
@@ -42,7 +53,7 @@
      if ( dim == AF_DIMENSION_HORZ )
      {
        scale = scaler->x_scale;
-@@ -920,7 +946,7 @@
+@@ -920,7 +950,7 @@
      {
        AF_LatinAxis  Axis = &metrics->axis[AF_DIMENSION_VERT];
        AF_LatinBlue  blue = NULL;
@@ -51,7 +62,7 @@
  
        for ( nn = 0; nn < Axis->blue_count; nn++ )
        {
-@@ -930,7 +956,12 @@
+@@ -930,7 +960,12 @@
            break;
          }
        }
@@ -65,7 +76,7 @@
        if ( blue )
        {
          FT_Pos   scaled;
-@@ -1049,7 +1080,13 @@
+@@ -1049,7 +1084,13 @@
  
          /* a blue zone is only active if it is less than 3/4 pixels tall */
          dist = FT_MulFix( blue->ref.org - blue->shoot.org, scale );
@@ -79,7 +90,7 @@
          {
  #if 0
            FT_Pos  delta1;
-@@ -1100,7 +1137,12 @@
+@@ -1100,7 +1141,12 @@
              delta2 = -delta2;
  
            blue->ref.fit   = FT_PIX_ROUND( blue->ref.cur );
@@ -92,7 +103,7 @@
  
  #endif
  
-@@ -1916,7 +1958,10 @@
+@@ -1916,7 +1962,10 @@
                dist = edge->fpos - blue->shoot.org;
                if ( dist < 0 )
                  dist = -dist;
@@ -104,7 +115,7 @@
                dist = FT_MulFix( dist, scale );
                if ( dist < best_dist )
                {
-@@ -2082,8 +2127,31 @@
+@@ -2082,8 +2131,31 @@
      FT_Pos           dist     = width;
      FT_Int           sign     = 0;
      FT_Int           vertical = ( dim == AF_DIMENSION_VERT );
@@ -136,7 +147,7 @@
      if ( !AF_LATIN_HINTS_DO_STEM_ADJUST( hints ) ||
           axis->extra_light                       )
        return width;
-@@ -2093,9 +2161,73 @@
+@@ -2093,9 +2165,73 @@
        dist = -width;
        sign = 1;
      }
@@ -186,8 +197,7 @@
 +            infinality_dist = 254;
 +          else infinality_dist = ( infinality_dist + 16 ) & ~63;
 +        }
- 
--    if ( (  vertical && !AF_LATIN_HINTS_DO_VERT_SNAP( hints ) ) ||
++
 +      }
 +      if ( infinality_dist < 52 )
 +      {
@@ -204,14 +214,15 @@
 +              ( ( vertical && !AF_LATIN_HINTS_DO_VERT_SNAP( hints ) )  ||
 +                ( !vertical && !AF_LATIN_HINTS_DO_HORZ_SNAP( hints ) ) ) )
 +#else
-+
+ 
+-    if ( (  vertical && !AF_LATIN_HINTS_DO_VERT_SNAP( hints ) ) ||
 +    if ( ( vertical && !AF_LATIN_HINTS_DO_VERT_SNAP( hints ) ) ||
           ( !vertical && !AF_LATIN_HINTS_DO_HORZ_SNAP( hints ) ) )
 +#endif /* FT_CONFIG_OPTION_INFINALITY_PATCHSET */
      {
        /* smooth hinting process: very lightly quantize the stem width */
  
-@@ -2155,6 +2287,9 @@
+@@ -2155,6 +2291,9 @@
        }
      }
      else
@@ -221,7 +232,7 @@
      {
        /* strong hinting process: snap the stem width to integer pixels */
  
-@@ -2162,7 +2297,10 @@
+@@ -2162,7 +2301,10 @@
  
  
        dist = af_latin_snap_width( axis->widths, axis->width_count, dist );
@@ -233,7 +244,7 @@
        if ( vertical )
        {
          /* in the case of vertical hinting, always round */
-@@ -2225,6 +2363,32 @@
+@@ -2225,6 +2367,32 @@
      }
  
    Done_Width:
@@ -266,7 +277,7 @@
      if ( sign )
        dist = -dist;
  
-@@ -2247,6 +2411,8 @@
+@@ -2247,6 +2415,8 @@
                               (AF_Edge_Flags)base_edge->flags,
                               (AF_Edge_Flags)stem_edge->flags );
  
@@ -275,7 +286,7 @@
  
      stem_edge->pos = base_edge->pos + fitted_width;
  
-@@ -2810,8 +2976,32 @@
+@@ -2810,8 +2980,32 @@
      int       dim;
  
      AF_LatinAxis  axis;
@@ -309,19 +320,14 @@
      error = af_glyph_hints_reload( hints, outline );
      if ( error )
        goto Exit;
-@@ -2877,7 +3067,17 @@
+@@ -2877,7 +3071,11 @@
      }
  
      af_glyph_hints_save( hints, outline );
+-
 +#ifdef FT_CONFIG_OPTION_INFINALITY_PATCHSET
 +    {
-+      /* Save this width for use in ftsmooth.c.  This is a shameful hack */
-+      const char* c1 = "CUR_WIDTH";
-+      char        c2[8];
- 
-+
-+      snprintf( c2, 8, "%ld", metrics->axis->widths[0].cur );
-+      setenv( c1, c2, 1 );
++      infinality_cur_width = metrics->axis->widths[0].cur;
 +    }
 +#endif /* FT_CONFIG_OPTION_INFINALITY_PATCHSET */
    Exit:

--- a/05-ftobjs.c.patch
+++ b/05-ftobjs.c.patch
@@ -1,5 +1,5 @@
---- a/src/base/ftobjs.c	2014-02-08 13:51:31.000000000 +0100
-+++ b/src/base/ftobjs.c	2014-03-07 19:21:57.073320788 +0100
+--- a/src/base/ftobjs.c	2014-09-14 11:35:20.947193822 -0500
++++ b/src/base/ftobjs.c	2014-09-14 11:59:30.672221004 -0500
 @@ -67,6 +67,10 @@
  
  #define GRID_FIT_METRICS
@@ -50,7 +50,7 @@
 +    {
 +      char *use_various_tweaks_env =
 +        getenv( "INFINALITY_FT_USE_VARIOUS_TWEAKS" );
-+
+ 
 +      if ( use_various_tweaks_env != NULL )
 +      {
 +        if ( strcasecmp(use_various_tweaks_env, "default" ) != 0 )
@@ -67,7 +67,7 @@
 +      }
 +      checked_use_various_tweaks_env = 1;
 +    }
- 
++
 +    /* Force autohint if no tt instructions */
 +    /* NOTE:  NEEDS TO BE RUN LATER IN CODE???? */
 +    /*if ( use_various_tweaks                             &&
@@ -97,23 +97,11 @@
  
        /* try to load embedded bitmaps first if available            */
        /*                                                            */
-@@ -723,6 +790,10 @@
-     }
-     else
-     {
-+#ifdef FT_CONFIG_OPTION_INFINALITY_PATCHSET
-+      char* c1 = "CUR_WIDTH";
-+      char* c2 = "0";
-+#endif
-       error = driver->clazz->load_glyph( slot,
-                                          face->size,
-                                          glyph_index,
-@@ -730,6 +801,18 @@
+@@ -730,6 +797,17 @@
        if ( error )
          goto Exit;
  
 +#ifdef FT_CONFIG_OPTION_INFINALITY_PATCHSET
-+      setenv ( c1, c2, 1 );
 +
 +      {
 +        /* fix for sdl_ttf */
@@ -127,4 +115,3 @@
        if ( slot->format == FT_GLYPH_FORMAT_OUTLINE )
        {
          /* check that the loaded outline is correct */
-

--- a/08-ftsmooth.c.patch
+++ b/08-ftsmooth.c.patch
@@ -1,5 +1,5 @@
---- a/src/smooth/ftsmooth.c	2013-06-05 12:12:47.000000000 +0200
-+++ b/src/smooth/ftsmooth.c	2014-03-07 19:21:57.079987455 +0100
+--- a/src/smooth/ftsmooth.c	2013-06-05 05:12:47.000000000 -0500
++++ b/src/smooth/ftsmooth.c	2014-09-14 11:55:39.848343363 -0500
 @@ -26,6 +26,17 @@
  
  #include "ftsmerrs.h"
@@ -18,7 +18,7 @@
  
    /* initialize renderer -- init its raster */
    static FT_Error
-@@ -93,6 +104,2997 @@
+@@ -93,6 +104,2993 @@
        FT_Outline_Get_CBox( &slot->outline, cbox );
    }
  
@@ -1603,15 +1603,11 @@
 +    FT_Bool         checked_use_known_settings_on_selected_fonts_env = FALSE;
 +    FT_Bool         use_known_settings_on_selected_fonts = FALSE;
 +
-+    int cur_width;
-+    char *cur_width_env = getenv( "CUR_WIDTH" );
++    FT_Pos          cur_width = infinality_cur_width;
 +
 +
-+
-+    if ( cur_width_env != NULL )
++    if ( cur_width )
 +    {
-+      sscanf ( cur_width_env, "%d", &cur_width );
-+      if ( cur_width != 0 )
 +        autohinted = TRUE;
 +    }
 +
@@ -3016,7 +3012,7 @@
  
    /* convert a slot's glyph image into a bitmap */
    static FT_Error
-@@ -104,8 +3106,9 @@
+@@ -104,8 +3102,9 @@
    {
      FT_Error     error;
      FT_Outline*  outline = NULL;
@@ -3027,7 +3023,7 @@
  #ifndef FT_CONFIG_OPTION_SUBPIXEL_RENDERING
      FT_Pos       height_org, width_org;
  #endif
-@@ -123,6 +3126,483 @@
+@@ -123,6 +3122,479 @@
      FT_Bool  have_outline_shifted   = FALSE;
      FT_Bool  have_buffer            = FALSE;
  
@@ -3094,8 +3090,7 @@
 +    int          checked_use_various_tweaks_env = 0;
 +    FT_Bool      use_various_tweaks = FALSE;
 +
-+    int          cur_width;
-+    char         *cur_width_env = getenv( "CUR_WIDTH" );
++    FT_Pos        cur_width = infinality_cur_width;
 +
 +    const FT_Int MIN_PPEM = 1;
 +    /*const FT_Int    MAX_PPEM = 100;    */
@@ -3110,11 +3105,8 @@
 +    else
 +      ppem = 0;
 +
-+    if ( cur_width_env != NULL )
++    if ( cur_width )
 +    {
-+      sscanf ( cur_width_env, "%d", &cur_width );
-+
-+      if ( cur_width != 0 )
 +        autohinted = TRUE;
 +    }
 +
@@ -3511,7 +3503,7 @@
  
      /* check glyph image format */
      if ( slot->format != render->glyph_format )
-@@ -138,9 +3618,105 @@
+@@ -138,9 +3610,105 @@
        goto Exit;
      }
  
@@ -3617,7 +3609,7 @@
      if ( origin )
      {
        FT_Outline_Translate( outline, origin->x, origin->y );
-@@ -154,6 +3730,7 @@
+@@ -154,6 +3722,7 @@
      cbox.yMin = FT_PIX_FLOOR( cbox.yMin );
      cbox.xMax = FT_PIX_CEIL( cbox.xMax );
      cbox.yMax = FT_PIX_CEIL( cbox.yMax );
@@ -3625,7 +3617,7 @@
  
      if ( cbox.xMin < 0 && cbox.xMax > FT_INT_MAX + cbox.xMin )
      {
-@@ -227,6 +3804,9 @@
+@@ -227,6 +3796,9 @@
          y_top   += extra >> 1;
        }
      }
@@ -3635,7 +3627,7 @@
  
  #endif
  
-@@ -251,8 +3831,15 @@
+@@ -251,8 +3823,15 @@
      bitmap->pitch      = pitch;
  
      /* translate outline to render it into the bitmap */
@@ -3651,7 +3643,7 @@
  
      if ( FT_ALLOC( bitmap->buffer, (FT_ULong)pitch * height ) )
        goto Exit;
-@@ -306,9 +3893,153 @@
+@@ -306,9 +3885,153 @@
      if ( error )
        goto Exit;
  

--- a/10-aflatin.h.patch
+++ b/10-aflatin.h.patch
@@ -1,0 +1,12 @@
+--- a/src/autofit/aflatin.h	2014-09-14 11:18:00.268465365 -0500
++++ b/src/autofit/aflatin.h	2014-09-14 11:23:45.223942422 -0500
+@@ -62,6 +62,9 @@
+ 
+ #define AF_LATIN_MAX_WIDTHS  16
+ 
++#ifdef FT_CONFIG_OPTION_INFINALITY_PATCHSET
++    extern FT_Pos infinality_cur_width;
++#endif
+ 
+   enum
+   {


### PR DESCRIPTION
Instead track cur_width through the global FT_Pos infinality_cur_width. This will
hopefully make the infinality patches more stable rxvt-unicode and other
programs that extensively modify the environment.
