### PR TITLE
Update 65-non-latin-free.conf

### DIFF
--- a/fontconfig_patches/free/65-non-latin-free.conf
+++ b/fontconfig_patches/free/65-non-latin-free.conf
@@ -41,10 +41,10 @@
     <family>sans-serif</family>
     <prefer>
       <!-- CJK -->
-      <family>Noto Sans Japanese</family>
-      <family>Noto Sans T Chinese</family>
-      <family>Noto Sans Korean</family>
-      <family>Noto Sans S Chinese</family>
+      <family>Noto Sans CJK JP</family>
+      <family>Noto Sans CJK TC</family>
+      <family>Noto Sans CJK KR</family>
+      <family>Noto Sans CJK SC</family>
       <family>Noto Sans Cherokee</family>
       <!-- Tibetan, Bod Skad, Dzongkha  -->
       <family>DDC Uchen</family>          <!-- serif -->


### PR DESCRIPTION
The Noto Sans CJK fonts have been renamed in newest infinality-bundle-fonts repo, old font substitution rules wouldn't apply any more, and causes CJK fonts to be rendered very ugly.
